### PR TITLE
Allow package to be installed by laravel 5.7.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "laravel/framework": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*"
+        "laravel/framework": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35"


### PR DESCRIPTION
This is a simple change involving adding laravel 5.7.* in composer.json file. 