### PR TITLE
Use `Arr::get` instead of the deprecated `array_get`

### DIFF
--- a/src/OnboardingStep.php
+++ b/src/OnboardingStep.php
@@ -2,6 +2,8 @@
 
 namespace Calebporzio\Onboard;
 
+use Illuminate\Support\Arr;
+
 /**
  * The main class for this package. This contains all the logic
  * for creating, and accessing onboarding steps.
@@ -126,7 +128,7 @@ class OnboardingStep
 	 */
 	public function attribute($key, $default = null)
     {
-        return array_get($this->attributes, $key, $default);
+        return Arr::get($this->attributes, $key, $default);
     }
 
     /**


### PR DESCRIPTION
In Laravel 6 the array_* helpers has been removed from the core framework (https://laravel.com/docs/6.x/upgrade#helpers)
So changed it to use the `Illuminate\Support\Arr` class instead, and that is also the same in previous versions.

https://github.com/calebporzio/onboard/issues/22