### PR TITLE
Fix typo and improve PHPUnit fixtures

### DIFF
--- a/tests/OnboardTest.php
+++ b/tests/OnboardTest.php
@@ -11,7 +11,7 @@ class OnboardTest extends TestCase
      */
     protected $user;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->user = $this->getMock('User');
     }
@@ -140,7 +140,7 @@ class OnboardTest extends TestCase
 
         $onboarding = new OnboardingManager($user, $onboardingSteps);
 
-        // Calling finished() will triger the completeIf callback.
+        // Calling finished() will trigger the completeIf callback.
         $this->assertTrue($onboarding->finished());
     }
 }


### PR DESCRIPTION
As title.

According to the official [PHPUnit doc](https://phpunit.de/manual/4.8/en/fixtures.html#fixtures.more-setup-than-teardown), it should be the `protected function setUp` and `protected function tearDown` methods.